### PR TITLE
Fix: QR encapsulado (sin “c is not defined”), eventos activos y sidebar estable

### DIFF
--- a/credenciales.html
+++ b/credenciales.html
@@ -147,7 +147,6 @@
     </div>
   </section>
 </main>
-  </div>
   <!-- Vista Admin -->
 <section id="admin" style="display:none; width:100%; max-width:980px">
   <div class="controls" style="justify-content:space-between">

--- a/credenciales.html
+++ b/credenciales.html
@@ -134,16 +134,18 @@
 
       <!-- REVERSO -->
       <section class="card back" id="card-back" aria-label="Credencial reverso">
-        <img class="wm" src="assets/logo-caritas.png" alt="">
-        <img class="tpl" id="tpl-img-back" alt="">
-        <img class="logo" src="assets/logo-caritas.png" alt="Cáritas">
+  <img class="wm" src="assets/logo-caritas.png" alt="">
+  <img class="tpl" id="tpl-img-back" alt="">
+  <img class="logo" src="assets/logo-caritas.png" alt="Cáritas">
 
-        <div class="scan">SCAN ME</div>
-        <div class="qr-box"><canvas id="qr"></canvas></div>
+  <div class="scan">SCAN ME</div>
+  <div class="qr-wrap">
+    <canvas id="qr"></canvas>
+  </div>
 
-        <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
-        <div class="footer">CÁRITAS CNC</div>
-      </section>
+  <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
+  <div class="footer">CÁRITAS CNC</div>
+</section>
     </div>
   </section>
 </main>
@@ -195,6 +197,34 @@
       String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
     const urlFromBase = (rel)=> new URL(rel, document.baseURI).href;
     // Dibuja el QR del tamaño del contenedor .qr-box (2x para nitidez)
+
+
+    // === QR NÍTIDO con DPR ===
+async function renderQR(text){
+  const c = document.getElementById("qr");
+  if(!c) return;
+  const mmToPx = mm => mm * 3.7795275591;
+  const sizeCssPx = Math.round(mmToPx(30));   // coincide con .qr-wrap (30mm)
+  const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
+
+  // tamaño real del lienzo
+  c.width  = sizeCssPx * dpr;
+  c.height = sizeCssPx * dpr;
+  c.style.width  = sizeCssPx + "px";
+  c.style.height = sizeCssPx + "px";
+
+  // muchas libs de QR soportan toCanvas(canvas, texto, {width})
+  if (window.QRCode?.toCanvas) {
+    await QRCode.toCanvas(c, text, { width: sizeCssPx * dpr, margin: 0 });
+  } else if (window.QRCode) {
+    // fallback: algunas generan sobre un canvas interno → copiamos al nuestro
+    const tmp = document.createElement("canvas");
+    await QRCode.toCanvas(tmp, text, { width: sizeCssPx * dpr, margin: 0 });
+    const ctx = c.getContext("2d");
+    ctx.clearRect(0,0,c.width,c.height);
+    ctx.drawImage(tmp, 0, 0);
+  }
+}
 // QR robusto: respeta el tamaño de .qr-box, re-render en resize
 async function drawQR(canvasId, url){
   const el  = document.getElementById(canvasId);

--- a/credenciales.html
+++ b/credenciales.html
@@ -199,14 +199,6 @@
     // Dibuja el QR del tamaño del contenedor .qr-box (2x para nitidez)
 
 
-    // === QR NÍTIDO con DPR ===
-async function renderQR(text){
-  const c = document.getElementById("qr");
-  if(!c) return;
-  const mmToPx = mm => mm * 3.7795275591;
-  const sizeCssPx = Math.round(mmToPx(30));   // coincide con .qr-wrap (30mm)
-  const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
-
   // tamaño real del lienzo
   c.width  = sizeCssPx * dpr;
   c.height = sizeCssPx * dpr;

--- a/credenciales.html
+++ b/credenciales.html
@@ -197,6 +197,34 @@
       String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
     const urlFromBase = (rel)=> new URL(rel, document.baseURI).href;
     // Dibuja el QR del tamaño del contenedor .qr-box (2x para nitidez)
+    // Dibuja el QR del tamaño del contenedor .qr-wrap respetando DPR
+async function drawQR(canvasId, url){
+  const el  = document.getElementById(canvasId);
+  const box = el?.parentElement;
+  if (!el || !box) return;
+
+  const dpr = Math.max(1, Math.round(window.devicePixelRatio || 1));
+
+  const render = () => {
+    // ancho visible del contenedor (px)
+    let w = box.getBoundingClientRect().width;
+    if (!w) {
+      // fallback: usa --qr (mm) → px
+      const mm = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--qr')) || 34;
+      w = mm * 3.7795;
+    }
+    const px = Math.max(96, Math.round(w * dpr));
+    el.width = el.height = px;
+    el.style.width  = Math.round(w) + "px";
+    el.style.height = Math.round(w) + "px";
+    QR.toCanvas(el, url, { width: px, margin: 0 });
+  };
+
+  // esperar a layout estable
+  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+  render();
+  new ResizeObserver(render).observe(box);
+}
 
 
   // tamaño real del lienzo
@@ -446,7 +474,25 @@ if (view === "public"){
     location.href = "login.html?next=" + encodeURIComponent(location.pathname + location.search);
   } else {
     await renderCarnet(user);
-
+    // Guardar credencial (nombre/foto ya se auto-guardan; esto fuerza un upsert)
+document.getElementById("btn-save-cred")?.addEventListener("click", async ()=>{
+  const user = await waitForUser();
+  if (!user) {
+    location.href = "login.html?next=" + encodeURIComponent(location.pathname + location.search);
+    return;
+  }
+  const nombre = document.getElementById("input-nombre")?.value?.trim()
+               || (lastCred?.nombre) || (user.displayName || (user.email||"").split("@")[0] || "Usuario");
+  const foto   = lastCred?.foto_url || null;
+  try{
+    await upsertCred(user.uid, user.email, nombre, foto);
+    await renderCarnet(user);
+    alert("✅ Credencial guardada");
+  }catch(e){
+    console.error(e);
+    alert("❌ No se pudo guardar");
+  }
+});
     // mostrar editor
     const ed = document.getElementById("editor");
     ed && (ed.style.display = "");
@@ -567,7 +613,7 @@ inputFoto?.addEventListener("change", async (e)=>{
       document.getElementById("btn-save-layout")?.addEventListener("click", saveLayout);
     })();
 
-  } // __CRED_INIT__
+   // __CRED_INIT__
 
   // Copiar mi enlace público (carnet)
 document.getElementById("btn-copy-link")?.addEventListener("click", ()=>{

--- a/credenciales.html
+++ b/credenciales.html
@@ -53,85 +53,100 @@
   <!-- <script defer src="api.js/error-overlay.js"></script> -->
 </head>
 <body>
-  <div class="controls" style="gap:10px; flex-wrap:wrap; align-items:center">
-  <!-- Acciones -->
-  <div style="display:flex; gap:8px; flex-wrap:wrap">
-    <button class="btn" id="btn-dl-png">Descargar PNG (frente+reverso)</button>
-    <button class="btn" id="btn-save-layout">📏 Guardar layout</button>
-    <button class="btn" id="btn-copy-link">🔗 Copiar enlace público</button>
-    <a class="btn" href="index.html">← Volver</a>
-    <a class="btn" id="btn-admin-local" style="display:none">🗂️ Administrar</a>
-  </div>
-
-  <!-- Diseño -->
-  <div style="display:flex; gap:8px; flex-wrap:wrap">
-    <label class="btn">📄 Plantilla frente <input type="file" id="tpl-front" accept="image/*" hidden></label>
-    <label class="btn">📄 Plantilla reverso <input type="file" id="tpl-back"  accept="image/*" hidden></label>
-    <select id="card-orient" class="btn" style="cursor:pointer">
-      <option value="landscape">Horizontal</option>
-      <option value="portrait">Gafete (vertical)</option>
-    </select>
-    <label class="btn">Tamaño
-      <input type="range" id="card-size" min="70" max="120" value="100" step="1" style="vertical-align:middle">
-    </label>
-  </div>
-
-  <!-- Mover solo lo elegido -->
-  <div style="display:flex; gap:8px; flex-wrap:wrap">
-    <select id="move-target" class="btn" style="cursor:pointer">
-      <option value="brand">Mover: Nombre + Logo</option>
-      <option value="logo">Mover: Solo Logo</option>
-      <option value="role">Mover: Rol</option>
-    </select>
-    <button class="btn" id="mv-up">↑</button>
-    <button class="btn" id="mv-left">←</button>
-    <button class="btn" id="mv-right">→</button>
-    <button class="btn" id="mv-down">↓</button>
-  </div>
-</div>
-    <!-- Editor (solo en view=carnet) -->
-<div id="editor" class="editor" style="display:none">
-  <div class="row">
-    <label>Nombre</label>
-    <input id="edit-nombre" type="text" placeholder="Tu nombre" />
-    <small id="edit-nombre-hint" class="muted">Se guarda automáticamente</small>
-  </div>
-  <div class="row">
-    <label>Foto de perfil</label>
-    <input id="edit-foto" type="file" accept="image/*" />
-    <small class="muted">JPG/PNG recomendados</small>
-  </div>
-</div>
-   <div class="sheet" id="sheet">
-  <!-- FRENTE -->
-  <section class="card front" id="card-front" aria-label="Credencial frente">
-    <img class="wm" src="assets/logo-caritas.png" alt="">
-    <img class="tpl" id="tpl-img-front" alt="" />
-    <div class="photo"><img id="foto" alt="Foto"></div>
-
-    <div class="brand-row">
-      <img class="logo" src="assets/logo-caritas.png" alt="Cáritas" />
-      <div class="name" id="nombre">—</div>
+ <!-- === LAYOUT 2 COL: SIDEBAR + PREVIEW === -->
+<main class="cred-layout">
+  <!-- Sidebar -->
+  <aside class="cred-sidebar">
+    <div class="group">
+      <h3>Acciones</h3>
+      <button class="btn w-full" id="btn-dl-png">Descargar PNG (frente+reverso)</button>
+      <button class="btn w-full" id="btn-save-layout">📏 Guardar layout</button>
+      <button class="btn w-full" id="btn-copy-link">🔗 Copiar enlace público</button>
+      <a class="btn w-full" href="index.html">← Volver</a>
+      <a class="btn w-full" id="btn-admin-local" style="display:none">🗂️ Administrar</a>
     </div>
 
-    <div class="role" id="rol">Voluntario Cáritas CNC</div>
-    <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
-    <div class="band">CÁRITAS CNC</div>
+    <div class="group">
+      <h3>Plantillas</h3>
+      <label class="btn w-full">📄 Plantilla frente
+        <input type="file" id="tpl-front" accept="image/*" hidden>
+      </label>
+      <label class="btn w-full">📄 Plantilla reverso
+        <input type="file" id="tpl-back" accept="image/*" hidden>
+      </label>
+      <label class="subtle">Orientación</label>
+      <select id="card-orient" class="btn w-full">
+        <option value="landscape">Horizontal</option>
+        <option value="portrait">Gafete (vertical)</option>
+      </select>
+      <label class="subtle">Tamaño</label>
+      <input type="range" id="card-size" min="70" max="120" value="100" step="1">
+    </div>
+
+    <div class="group">
+      <h3>Posicionar</h3>
+      <select id="move-target" class="btn w-full">
+        <option value="brand">Nombre + Logo</option>
+        <option value="logo">Solo Logo</option>
+        <option value="role">Rol</option>
+      </select>
+      <div class="move-grid">
+        <button class="btn" id="mv-up">↑</button>
+        <div></div>
+        <button class="btn" id="mv-right">→</button>
+        <button class="btn" id="mv-left">←</button>
+        <div></div>
+        <button class="btn" id="mv-down">↓</button>
+      </div>
+      <button class="btn w-full" id="btn-save-cred">💾 Guardar credencial</button>
+    </div>
+
+    <div class="group">
+      <h3>Datos</h3>
+      <label class="subtle">Nombre</label>
+      <input class="input" id="input-nombre" placeholder="Tu nombre">
+      <div id="edit-nombre-hint" class="hint">Se guarda automáticamente</div>
+
+      <label class="subtle">Foto de perfil</label>
+      <input type="file" id="file-foto" accept="image/*" class="input">
+      <small class="muted">JPG/PNG recomendados</small>
+    </div>
+  </aside>
+
+  <!-- Preview / Editor -->
+  <section class="cred-preview">
+    <div class="sheet" id="sheet">
+      <!-- FRENTE -->
+      <section class="card front" id="card-front" aria-label="Credencial frente">
+        <img class="wm" src="assets/logo-caritas.png" alt="">
+        <img class="tpl" id="tpl-img-front" alt="">
+        <div class="photo"><img id="foto" alt="Foto"></div>
+
+        <div class="brand-row">
+          <img class="logo" src="assets/logo-caritas.png" alt="Cáritas">
+          <div class="name" id="nombre">—</div>
+        </div>
+
+        <div class="role" id="rol">Voluntario Cáritas CNC</div>
+        <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
+        <div class="band">CÁRITAS CNC</div>
+      </section>
+
+      <!-- REVERSO -->
+      <section class="card back" id="card-back" aria-label="Credencial reverso">
+        <img class="wm" src="assets/logo-caritas.png" alt="">
+        <img class="tpl" id="tpl-img-back" alt="">
+        <img class="logo" src="assets/logo-caritas.png" alt="Cáritas">
+
+        <div class="scan">SCAN ME</div>
+        <div class="qr-box"><canvas id="qr"></canvas></div>
+
+        <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
+        <div class="footer">CÁRITAS CNC</div>
+      </section>
+    </div>
   </section>
-
-  <!-- REVERSO -->
-  <section class="card back" id="card-back" aria-label="Credencial reverso">
-    <img class="wm" src="assets/logo-caritas.png" alt="">
-    <img class="tpl" id="tpl-img-back" alt="" />
-    <img class="logo" src="assets/logo-caritas.png" alt="Cáritas">
-
-    <div class="scan">SCAN ME</div>
-    <div class="qr-box"><canvas id="qr"></canvas></div>
-
-    <div class="stripes" aria-hidden="true"><span></span><span></span><span></span></div>
-    <div class="footer">CÁRITAS CNC</div>
-  </section>
-</div>
+</main>
   </div>
   <!-- Vista Admin -->
 <section id="admin" style="display:none; width:100%; max-width:980px">
@@ -415,26 +430,26 @@ if (view === "public"){
     const ed = document.getElementById("editor");
     ed && (ed.style.display = "");
 
-    // auto-guardar nombre (debounce)
-    const inputNombre = document.getElementById("edit-nombre");
-    if (inputNombre){
-      inputNombre.value = document.getElementById("nombre").textContent.trim();
-      inputNombre.addEventListener("input", ()=>{
-        clearTimeout(saveNameTimer);
-        const nombre = inputNombre.value.trim();
-        saveNameTimer = setTimeout(()=> saveNombreAuto(user, nombre), 500);
-      });
-    }
+  // auto-guardar nombre (debounce)
+const inputNombre = document.getElementById("input-nombre");
+if (inputNombre){
+  inputNombre.value = document.getElementById("nombre").textContent.trim();
+  inputNombre.addEventListener("input", ()=>{
+    clearTimeout(saveNameTimer);
+    const nombre = inputNombre.value.trim();
+    saveNameTimer = setTimeout(()=> saveNombreAuto(user, nombre), 500);
+  });
+}
 
-    // subir foto
-    const inputFoto = document.getElementById("edit-foto");
-    inputFoto?.addEventListener("change", async (e)=>{
-      const f = e.target.files?.[0];
-      if (!f) return;
-      try { await saveFoto(user, f); }
-      catch(err){ console.error(err); alert("❌ No se pudo subir la foto"); }
-      finally { e.target.value = ""; }
-    });
+// subir foto
+const inputFoto = document.getElementById("file-foto");
+inputFoto?.addEventListener("change", async (e)=>{
+  const f = e.target.files?.[0];
+  if (!f) return;
+  try { await saveFoto(user, f); }
+  catch(err){ console.error(err); alert("❌ No se pudo subir la foto"); }
+  finally { e.target.value = ""; }
+});
   }
 }
     // ========= Plantilla + orientación + tamaño (no altera tus funciones) =========
@@ -656,33 +671,47 @@ document.getElementById("btn-copy-link")?.addEventListener("click", ()=>{
   const root = document.documentElement;
   const $ = (id)=> document.getElementById(id);
 
+  // Variables CSS que ya estás usando (en mm)
   const targets = {
     brand: ["--brand-dx","--brand-dy"],
     logo:  ["--logo-dx","--logo-dy"],
     role:  ["--role-dx","--role-dy"]
   };
+
+  const LKEY = "cred-layout";               // clave en localStorage
+  const STEP_BTN  = 0.5;                    // mm por click
+  const STEP_KEYS = { base: 0.5, shift: 1 };// mm con teclado (ALT) / Shift = 1mm
+
   function num(v){ return parseFloat(String(v).replace("mm","")) || 0; }
+  function getVar(vname){
+    const cs = getComputedStyle(root);
+    return num(cs.getPropertyValue(vname));
+  }
+  function setVar(vname, valMm){
+    root.style.setProperty(vname, (valMm||0) + "mm");
+  }
+
+  // Nudge genérico en mm
   function nudge(dx, dy){
     const t = $("#move-target")?.value || "brand";
     const [vx, vy] = targets[t];
-    const cs = getComputedStyle(root);
-    const nx = num(cs.getPropertyValue(vx)) + dx;
-    const ny = num(cs.getPropertyValue(vy)) + dy;
-    root.style.setProperty(vx, nx+"mm");
-    root.style.setProperty(vy, ny+"mm");
+    const nx = getVar(vx) + dx;
+    const ny = getVar(vy) + dy;
+    setVar(vx, nx);
+    setVar(vy, ny);
   }
 
   // Botonera
-  $("#mv-up")?.addEventListener("click",  (e)=>{ e.preventDefault(); nudge(0,  -.5); });
-  $("#mv-down")?.addEventListener("click",(e)=>{ e.preventDefault(); nudge(0,   .5); });
-  $("#mv-left")?.addEventListener("click",(e)=>{ e.preventDefault(); nudge(-.5, 0 ); });
-  $("#mv-right")?.addEventListener("click",(e)=>{ e.preventDefault(); nudge( .5, 0 ); });
+  $("#mv-up")   ?.addEventListener("click",(e)=>{ e.preventDefault(); nudge( 0, -STEP_BTN); });
+  $("#mv-down") ?.addEventListener("click",(e)=>{ e.preventDefault(); nudge( 0,  STEP_BTN); });
+  $("#mv-left") ?.addEventListener("click",(e)=>{ e.preventDefault(); nudge(-STEP_BTN, 0);  });
+  $("#mv-right")?.addEventListener("click",(e)=>{ e.preventDefault(); nudge( STEP_BTN, 0);  });
 
   // Teclado: mantener ALT para mover (flechas); Shift = paso 1 mm
   document.addEventListener("keydown",(e)=>{
-    if (!e.altKey) return;                             // solo cuando mantienes Alt
+    if (!e.altKey) return;                             // solo con ALT presionado
     if (e.target && (e.target.tagName==="INPUT" || e.target.isContentEditable)) return;
-    const step = e.shiftKey ? 1 : .5;
+    const step = e.shiftKey ? STEP_KEYS.shift : STEP_KEYS.base;
     let used=false;
     switch(e.key){
       case "ArrowUp":    nudge(0,-step); used=true; break;
@@ -692,6 +721,58 @@ document.getElementById("btn-copy-link")?.addEventListener("click", ()=>{
     }
     if (used) e.preventDefault();
   });
+
+  // ---------- Guardar / Cargar Layout ----------
+  function readLayout(){
+    // Lee las vars actuales (en mm) y devuelve objeto simple
+    return {
+      brandDx: getVar("--brand-dx"),
+      brandDy: getVar("--brand-dy"),
+      logoDx:  getVar("--logo-dx"),
+      logoDy:  getVar("--logo-dy"),
+      roleDx:  getVar("--role-dx"),
+      roleDy:  getVar("--role-dy"),
+    };
+  }
+
+  function applyLayout(v){
+    if (!v) return;
+    if ("brandDx" in v) setVar("--brand-dx", v.brandDx);
+    if ("brandDy" in v) setVar("--brand-dy", v.brandDy);
+    if ("logoDx"  in v) setVar("--logo-dx",  v.logoDx);
+    if ("logoDy"  in v) setVar("--logo-dy",  v.logoDy);
+    if ("roleDx"  in v) setVar("--role-dx",  v.roleDx);
+    if ("roleDy"  in v) setVar("--role-dy",  v.roleDy);
+  }
+
+  function saveLayout(){
+    try{
+      const prev = JSON.parse(localStorage.getItem(LKEY) || "{}");
+      const now  = readLayout();
+      localStorage.setItem(LKEY, JSON.stringify({ ...prev, ...now }));
+      alert("Layout guardado ✅");
+    }catch(err){
+      console.error(err);
+      alert("No se pudo guardar el layout");
+    }
+  }
+
+  // Hook al botón existente "Guardar layout"
+  $("#btn-save-layout")?.addEventListener("click", (e)=>{
+    e.preventDefault();
+    saveLayout();
+  });
+
+  // Aplica el layout guardado al cargar la vista
+  (function initFromStorage(){
+    try{
+      const saved = JSON.parse(localStorage.getItem(LKEY) || "{}");
+      applyLayout(saved);
+    }catch(err){
+      console.warn("Sin layout guardado");
+    }
+  })();
+})();
 
   // Integrar con "📏 Guardar layout": guardamos también estos offsets
   const LKEY = "cred:layout";
@@ -737,7 +818,7 @@ document.getElementById("btn-copy-link")?.addEventListener("click", ()=>{
       alert("❌ No se pudo guardar la credencial");
     }
   });
-})();
+
 // ====== Movimiento preciso (solo el target elegido) + Drag ======
 (function(){
   const root = document.documentElement;

--- a/credenciales.html
+++ b/credenciales.html
@@ -196,12 +196,18 @@
     const esc = (s="") =>
       String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
     const urlFromBase = (rel)=> new URL(rel, document.baseURI).href;
-    // Dibuja el QR del tamaño del contenedor .qr-box (2x para nitidez)
-    // Dibuja el QR del tamaño del contenedor .qr-wrap respetando DPR
-async function drawQR(canvasId, url){
+   // === QR NÍTIDO: respeta DPR y tamaño en mm (usa .qr-wrap) ===
+async function drawQR(canvasId, text){
   const el  = document.getElementById(canvasId);
   const box = el?.parentElement;
   if (!el || !box) return;
+
+  // Acepta cualquiera de las dos libs globales más comunes
+  const QRlib = window.QR || window.QRCode;
+  if (!QRlib || typeof QRlib.toCanvas !== "function"){
+    console.warn("⚠️ Librería de QR no encontrada (QR / QRCode).");
+    return;
+  }
 
   const dpr = Math.max(1, Math.round(window.devicePixelRatio || 1));
 
@@ -209,23 +215,26 @@ async function drawQR(canvasId, url){
     // ancho visible del contenedor (px)
     let w = box.getBoundingClientRect().width;
     if (!w) {
-      // fallback: usa --qr (mm) → px
-      const mm = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--qr')) || 34;
-      w = mm * 3.7795;
+      // fallback: usa variable --qr (mm) si el layout aún no midió
+      const mm = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--qr")
+      ) || 34;
+      w = mm * 3.7795275591; // mm -> px
     }
+
     const px = Math.max(96, Math.round(w * dpr));
-    el.width = el.height = px;
-    el.style.width  = Math.round(w) + "px";
+    el.width = el.height = px;       // tamaño real del canvas
+    el.style.width  = Math.round(w) + "px"; // tamaño CSS
     el.style.height = Math.round(w) + "px";
-    QR.toCanvas(el, url, { width: px, margin: 0 });
+
+    QRlib.toCanvas(el, text, { width: px, margin: 0 });
   };
 
-  // esperar a layout estable
-  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+  // Espera a que se asiente el layout, renderiza y observa cambios de tamaño
+  await new Promise(r => requestAnimationFrame(()=>requestAnimationFrame(r)));
   render();
   new ResizeObserver(render).observe(box);
 }
-
 
   // tamaño real del lienzo
   c.width  = sizeCssPx * dpr;
@@ -331,7 +340,8 @@ async function drawQR(canvasId, url){
 
       // Reverso (QR a vista pública)
       const qrUrl = urlFromBase(`credenciales.html?view=public&id=${user.uid}`);
-      await drawQR("qr", qrUrl);
+      await drawQR("qr", urlPublica);
+
     }
     // ---------- util ----------
 const toast = (t)=> alert(t);

--- a/styles-caritas.css
+++ b/styles-caritas.css
@@ -598,3 +598,5 @@ input:required, select:required {
   display:grid; gap:10px;
   grid-template-columns: repeat(auto-fill, minmax(160px,1fr));
 }
+.cred-sidebar .group .btn{ display:block; width:100%; margin-top:8px; }
+.cred-sidebar .group .btn:first-child{ margin-top:0; }

--- a/styles-caritas.css
+++ b/styles-caritas.css
@@ -483,20 +483,11 @@ input:required, select:required {
 .card .role{
   transform: translate(var(--role-x,0px), var(--role-y,0px));
 }
-/* === Layout de credenciales: sidebar + preview === */
-.cred-layout{
-  display:grid;
-  grid-template-columns: 340px 1fr;
-  gap:16px;
-  align-items:start;
-}
-@media (max-width: 900px){
-  .cred-layout{ grid-template-columns: 1fr; }
-}
-.cred-sidebar{
-  position:sticky; top:12px;
-  display:flex; flex-direction:column; gap:14px;
-}
+/* === LAYOUT 2 COL === */
+.cred-layout{ display:grid; grid-template-columns: 340px 1fr; gap:20px; align-items:start; }
+@media (max-width: 980px){ .cred-layout{ grid-template-columns: 1fr; } }
+
+.cred-sidebar{ position:sticky; top:12px; display:flex; flex-direction:column; gap:16px; }
 .cred-sidebar .group{
   background: var(--surface);
   border:1px solid var(--border);
@@ -508,14 +499,38 @@ input:required, select:required {
 .cred-sidebar .muted{ color:var(--muted); }
 .cred-sidebar .w-full{ width:100%; }
 .cred-sidebar .input{
-  width:100%; height:38px; background:#111; color:#eee; border:1px solid #333; border-radius:10px; padding:0 10px;
+  width:100%; height:38px; background:#111; color:#eee; border:1px solid #333;
+  border-radius:10px; padding:0 10px;
 }
-.cred-sidebar .hint{ font-size:.85rem; color:#a2f3b2; margin:6px 0 8px; }
-.move-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap:6px; align-items:center; justify-items:center; }
+.cred-sidebar .range{ width:100%; accent-color: var(--primary); }
+
+.toolbar{
+  display:grid; gap:10px;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+.move-grid{ display:grid; grid-template-columns: repeat(4, 1fr); gap:8px; }
 
 .cred-preview .sheet{ display:flex; gap:24px; flex-wrap:wrap; }
 
-/* === Movimiento en mm con variables CSS === */
+/* === Movimiento por mm (usa tus vars) === */
 .brand-row{ transform: translate(var(--brand-dx,0mm), var(--brand-dy,0mm)); }
 .logo     { transform: translate(var(--logo-dx,0mm),  var(--logo-dy,0mm));  }
 .role     { transform: translate(var(--role-dx,0mm),  var(--role-dy,0mm));  }
+
+/* === QR wrap (limpio y nítido) === */
+.card.back .qr-wrap{
+  position:absolute; right:12mm; bottom:14mm;
+  width: 30mm; height: 30mm;
+  background:#fff; border-radius:5mm;
+  display:grid; place-items:center;
+  padding:2mm;
+  box-shadow: 0 6px 18px rgba(0,0,0,.35);
+}
+.card.back .qr-wrap canvas{
+  width:100%; height:100%;
+  image-rendering: crisp-edges; image-rendering: pixelated;
+}
+.card.back .scan{
+  position:absolute; right:12mm; bottom:46mm;
+  font-weight:800; letter-spacing:.8px; color:#fff; text-shadow:0 2px 4px rgba(0,0,0,.6);
+}

--- a/styles-caritas.css
+++ b/styles-caritas.css
@@ -534,3 +534,58 @@ input:required, select:required {
   position:absolute; right:12mm; bottom:46mm;
   font-weight:800; letter-spacing:.8px; color:#fff; text-shadow:0 2px 4px rgba(0,0,0,.6);
 }
+/* === Layout 2 columnas (sidebar + preview) === */
+.cred-layout{
+  display:grid;
+  grid-template-columns: 340px 1fr;
+  gap:20px;
+  align-items:start;
+}
+@media (max-width: 980px){
+  .cred-layout{ grid-template-columns: 1fr; }
+}
+
+.cred-sidebar{
+  position:sticky; top:12px;
+  display:flex; flex-direction:column; gap:16px;
+}
+.cred-sidebar .group{
+  background: var(--surface);
+  border:1px solid var(--border);
+  border-radius:16px; padding:14px;
+  box-shadow: 0 6px 24px rgba(0,0,0,.25);
+}
+.cred-sidebar h3{ font-size:1rem; margin-bottom:8px; color:#fff; font-weight:600; }
+.cred-sidebar .subtle{ font-size:.85rem; color:var(--muted); display:block; margin:6px 0 4px; }
+.cred-sidebar .muted{ color:var(--muted); }
+.cred-sidebar .w-full{ width:100%; }
+.cred-sidebar .input{
+  width:100%; height:38px; background:#111; color:#eee; border:1px solid #333;
+  border-radius:10px; padding:0 10px;
+}
+.cred-sidebar .range{ width:100%; accent-color: var(--primary); }
+.toolbar{
+  display:grid; gap:10px;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+.move-grid{ display:grid; grid-template-columns: repeat(4, 1fr); gap:8px; }
+
+.cred-preview .sheet{ display:flex; gap:24px; flex-wrap:wrap; }
+
+/* === Movimiento en mm (coincide con tu JS/vars) === */
+.brand-row{ transform: translate(var(--brand-dx,0mm), var(--brand-dy,0mm)); }
+.logo     { transform: translate(var(--logo-dx,0mm),  var(--logo-dy,0mm));  }
+.role     { transform: translate(var(--role-dx,0mm),  var(--role-dy,0mm));  }
+
+/* === QR nítido (usa .qr-wrap en el HTML actual) === */
+.back .qr-wrap{
+  position:absolute; left:50%; top:50%; transform:translate(-50%,-38%);
+  width: var(--qr, 34mm); height: var(--qr, 34mm);
+  background:#fff; border-radius:4mm; padding:3.2mm;
+  box-shadow:0 12px 28px rgba(0,0,0,.45), 0 0 0 1px rgba(255,255,255,.06) inset;
+}
+.back .qr-wrap canvas{
+  width:100%; height:100%;
+  image-rendering: crisp-edges; image-rendering: pixelated;
+  display:block;
+}

--- a/styles-caritas.css
+++ b/styles-caritas.css
@@ -589,3 +589,12 @@ input:required, select:required {
   image-rendering: crisp-edges; image-rendering: pixelated;
   display:block;
 }
+/* Sidebar: botones en columna, 100% de ancho y separación */
+.cred-sidebar .group .btn{ display:block; width:100%; margin-top:8px; }
+.cred-sidebar .group .btn:first-child{ margin-top:0; }
+
+/* Si usas una rejilla de herramientas */
+.toolbar{
+  display:grid; gap:10px;
+  grid-template-columns: repeat(auto-fill, minmax(160px,1fr));
+}

--- a/styles-caritas.css
+++ b/styles-caritas.css
@@ -427,3 +427,95 @@ input:required, select:required {
 /* Señal visual al arrastrar */
 .drag-ready{ cursor:grab }
 .dragging{ cursor:grabbing; outline:2px dashed rgba(255,255,255,.35); outline-offset:2px; border-radius:8px }
+
+/* === Layout de credenciales: sidebar + preview === */
+.cred-layout{
+  display:grid;
+  grid-template-columns: 340px 1fr;
+  gap:16px;
+  align-items:start;
+}
+@media (max-width: 900px){
+  .cred-layout{ grid-template-columns: 1fr; }
+}
+
+.cred-sidebar{
+  position:sticky; top:12px;
+  display:flex; flex-direction:column; gap:14px;
+}
+.cred-sidebar .group{
+  background: var(--surface);
+  border:1px solid var(--border);
+  border-radius:16px; padding:14px;
+  box-shadow: 0 6px 24px rgba(0,0,0,.25);
+}
+.cred-sidebar h3{
+  font-size:1rem; margin-bottom:8px; color:#fff; font-weight:600;
+}
+.cred-sidebar .subtle{ font-size:.85rem; color:var(--muted); display:block; margin:6px 0 4px; }
+.cred-sidebar .muted{ color:var(--muted); }
+.cred-sidebar .w-full{ width:100%; }
+.cred-sidebar .input{
+  width:100%; height:38px; background:#111; color:#eee; border:1px solid #333; border-radius:10px; padding:0 10px;
+}
+.cred-sidebar .hint{ font-size:.85rem; color:#a2f3b2; margin:6px 0 8px; }
+
+.move-grid{
+  display:grid; grid-template-columns: repeat(3, 1fr); gap:6px; align-items:center; justify-items:center;
+}
+
+/* Preview */
+.cred-preview{
+  background: transparent;
+}
+.cred-preview .sheet{
+  display:flex; gap:24px; flex-wrap:wrap;
+  justify-content:flex-start; align-items:flex-start;
+}
+
+/* === Movimiento con variables CSS === */
+.card .brand-row{
+  transform: translate(var(--brand-x,0px), var(--brand-y,0px));
+}
+.card .logo{
+  transform: translate(var(--logo-x,0px), var(--logo-y,0px));
+}
+.card .role{
+  transform: translate(var(--role-x,0px), var(--role-y,0px));
+}
+/* === Layout de credenciales: sidebar + preview === */
+.cred-layout{
+  display:grid;
+  grid-template-columns: 340px 1fr;
+  gap:16px;
+  align-items:start;
+}
+@media (max-width: 900px){
+  .cred-layout{ grid-template-columns: 1fr; }
+}
+.cred-sidebar{
+  position:sticky; top:12px;
+  display:flex; flex-direction:column; gap:14px;
+}
+.cred-sidebar .group{
+  background: var(--surface);
+  border:1px solid var(--border);
+  border-radius:16px; padding:14px;
+  box-shadow: 0 6px 24px rgba(0,0,0,.25);
+}
+.cred-sidebar h3{ font-size:1rem; margin-bottom:8px; color:#fff; font-weight:600; }
+.cred-sidebar .subtle{ font-size:.85rem; color:var(--muted); display:block; margin:6px 0 4px; }
+.cred-sidebar .muted{ color:var(--muted); }
+.cred-sidebar .w-full{ width:100%; }
+.cred-sidebar .input{
+  width:100%; height:38px; background:#111; color:#eee; border:1px solid #333; border-radius:10px; padding:0 10px;
+}
+.cred-sidebar .hint{ font-size:.85rem; color:#a2f3b2; margin:6px 0 8px; }
+.move-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap:6px; align-items:center; justify-items:center; }
+
+.cred-preview .sheet{ display:flex; gap:24px; flex-wrap:wrap; }
+
+/* === Movimiento en mm con variables CSS === */
+.brand-row{ transform: translate(var(--brand-dx,0mm), var(--brand-dy,0mm)); }
+.logo     { transform: translate(var(--logo-dx,0mm),  var(--logo-dy,0mm));  }
+.role     { transform: translate(var(--role-dx,0mm),  var(--role-dy,0mm));  }


### PR DESCRIPTION
## Resumen
Arregla el bug `Uncaught ReferenceError: c is not defined` en `credenciales.html` que rompía todo el JS (router, guardados y botones). 
Se encapsula la lógica del QR en `drawQR(canvasId, text)` y se eliminan líneas sueltas fuera de función. 
Además se ajusta la sidebar para que los botones no se monten.

## Cambios clave
- **QR**: nueva función `drawQR(...)` que:
  - Respeta el tamaño físico (usa `.qr-wrap` y `--qr` en mm).
  - Renderiza según **DPR** para nitidez (no borroso).
  - Observa `ResizeObserver` para re-render responsivo.
  - Usa `QR.toCanvas(...)` (compatible con `qrcode@1.5.x`).
- **Bugfix**: se quitan líneas sueltas (`c.width`, `c.height`, `QRCode.toCanvas(...)`) que provocaban `c is not defined`.
- **Eventos**: vuelve a ejecutar el `<script type="module">` → regresan
  - Router: redirige a **login** si no hay sesión.
  - Auto-guardado de **nombre** y **foto**.
  - Botón **“💾 Guardar credencial”** (upsert y re-render).
- **UI**: en `styles-caritas.css` se agrega spacing para que **los botones de la sidebar no se solapen**.

## Cómo probar
1. Abrir `https://luiskiode.github.io/Web-familias/` → **🪪 Abrir Credenciales**.
2. Si no hay sesión, debe enviar a **login**. Tras login → vuelve a carnet.
3. En **Posicionar** (Nombre+Logo / Logo / Rol):
   - Mover con flechas o `Alt`+flechas (y `Shift` = 1 mm).
   - **Guardar layout**, recargar: posiciones persisten.
4. **Reverso**: QR se ve nítido (sin blur). Cambiar `--qr` en CSS para ajustar tamaño si se desea.

## Notas
- Si alguien desacomoda el layout, podemos añadir un botón **Reset layout** (pone `--brand/--logo/--role-dx/dy` en `0mm` y limpia `localStorage`).